### PR TITLE
Fix GOPATH on go ver1.16

### DIFF
--- a/yo.tmpl.bash
+++ b/yo.tmpl.bash
@@ -2,6 +2,7 @@
 
 export PATH="$(pwd)/${GODIR}:${PATH}"
 source <("$(pwd)/${GODIR}/go" env)
+export GOPATH="$(pwd)/${GODIR}/go"
 
 YO_OPTS=""
 if [[ -n "${TEMPLATE_DIR}" ]]; then


### PR DESCRIPTION
This pullrequest is about fixing the GOPATH missing in go 1.16.
Thanks